### PR TITLE
Typo: clas -> clash

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ If you would like to write your own programs, feel free to use the [include file
 
 In ADL mode, the program is aware of the full address space. The Agon MOS loads programs by default to address $40000, so if ADL mode is set (#define ADL), the init.asm include file will set the .org $40000 directive.
 
-In Z80 legacy mode, the program will, from its point of view, be located from address $0000.  The program will have 32kb of address space to $7FFF available to itself. Note, the SPS stack expands downwards from $7FFF, so if your assembled code is very large, you need to make sure it doesn't clas with the stack. 
+In Z80 legacy mode, the program will, from its point of view, be located from address $0000.  The program will have 32kb of address space to $7FFF available to itself. Note, the SPS stack expands downwards from $7FFF, so if your assembled code is very large, you need to make sure it doesn't clash with the stack. 
 
 ### Assembling as MOS (*) commands
 
@@ -56,7 +56,7 @@ In addition, the SPS stack pointer needs to be set to $7FFE before starting to p
 
 ### The MOS executable format
 
-The MOS header is stored from bytes 64 in the executable and consists of the following:
+The MOS header is stored from byte 64 in the executable and consists of the following:
 
 - A three byte ASCII representation of the word MOS
 - A single byte for the header version


### PR DESCRIPTION
I also changed "bytes" to "byte" for clarity but I actually think "offset" would be the clearest wording.